### PR TITLE
Fix "No - candidates produce the expected return type CGFloat"

### DIFF
--- a/TGLParallaxCarousel/Classes/TGLParallaxCarousel.swift
+++ b/TGLParallaxCarousel/Classes/TGLParallaxCarousel.swift
@@ -201,7 +201,7 @@ open class TGLParallaxCarousel: UIView {
             item.layer.add(animationGroup, forKey: "myAnimation")
             
             var t = CATransform3DIdentity
-            t.m34 = -(1 / 500)
+            t.m34 = (-1 / 500)
             t = CATransform3DTranslate(t, xDispNew, 0.0, zDispNew)
             item.layer.transform = t;
             
@@ -322,7 +322,7 @@ open class TGLParallaxCarousel: UIView {
             DispatchQueue.main.async() {
                 UIView.animate(withDuration: 0.33, animations: { () -> Void in
                     var t = CATransform3DIdentity
-                    t.m34 = -(1 / 500)
+                    t.m34 = (-1 / 500)
                     item.layer.transform = CATransform3DTranslate(t, item.xDisp * factor , 0.0, item.zDisp)
                 })
             }


### PR DESCRIPTION
Getting a compile-time error with XCode 8.1 and Swift 3 caused by a minus sign before a paranthesis in:

``
t.m34 = -(1 / 500)
``

at lines 205 and 326.